### PR TITLE
增加deploy.sh 执行权限

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ NOTE: if you are using GPU Mounter on Kubernetes v1.13 or v1.14, you need to [ma
 ## Deploy
 
 ```bash
+chmod u+x deploy.sh
 ./deploy.sh deploy
 ```
 


### PR DESCRIPTION
按照文档操作，`deploy.sh`没有执行权限，报错如下 :
```
[root@t32 GPUMounter]# ./deploy.sh deploy
-bash: ./deploy.sh: Permission denied
```
需要给deloy.sh增加执行权限。